### PR TITLE
Make sure NSUserNotification(s) are presented 

### DIFF
--- a/Rhea/AppDelegate.m
+++ b/Rhea/AppDelegate.m
@@ -169,8 +169,8 @@ static NSString *const kRHEANotificationURLStringKey = @"url";
     }
 }
 
-- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
-     shouldPresentNotification:(NSUserNotification *)notification {
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification
+{
   return YES;
 }
 

--- a/Rhea/AppDelegate.m
+++ b/Rhea/AppDelegate.m
@@ -169,6 +169,11 @@ static NSString *const kRHEANotificationURLStringKey = @"url";
     }
 }
 
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
+     shouldPresentNotification:(NSUserNotification *)notification {
+  return YES;
+}
+
 #pragma mark - Drag & Drop
 
 - (id)resolveDraggingInfo:(id<NSDraggingInfo>)sender


### PR DESCRIPTION
In order to make sure notifications are shown even when the app is not in foreground or the user notification center has decided not to present a notification, we need to implement this method.

See: 
http://stackoverflow.com/questions/15896348/nsusernotificationcenter-not-showing-notifications

Reference:
https://developer.apple.com/library/mac/documentation/Foundation/Reference/NSUserNotificationCenterDelegate_Protocol/index.html#//apple_ref/occ/intfm/NSUserNotificationCenterDelegate/userNotificationCenter:shouldPresentNotification:
